### PR TITLE
Fix #51: allow compatibility of v2.0 with CakePHPv3.0 (instead of v3.4) during searches

### DIFF
--- a/src/Controller/Component/DataTablesComponent.php
+++ b/src/Controller/Component/DataTablesComponent.php
@@ -293,7 +293,7 @@ class DataTablesComponent extends Component
         if (strpos(strtolower($comparison), 'like') !== false) {
             $value = $this->config('prefixSearch') ? "{$value}%" : "%{$value}%";
             
-            if ($this->_table->getConnection()->getDriver() instanceof Postgres) {
+            if ($this->_table->connection()->driver() instanceof Postgres) {
                 $columnDesc = $table->schema()->column($column);
                 $columnType = $columnDesc['type'];
                 if ($columnType !== 'string' && $columnType !== 'text') {


### PR DESCRIPTION
As discussed in #51

Note: I created my branch from the **v2.0** tag. This PR should be merged "in this tag", if that makes sense. I'm not sure how to express that with github...